### PR TITLE
Fix typo in DataRequestParameters class name and add default paramete…

### DIFF
--- a/Querier.Api/Application/DTOs/SQLQueryDTO.cs
+++ b/Querier.Api/Application/DTOs/SQLQueryDTO.cs
@@ -96,6 +96,7 @@ namespace Querier.Api.Application.DTOs
                     ConnectionType = Enum.Parse<DbConnectionType>(sqlQuery.Connection.ConnectionType.ToString()),
                     ApiRoute = sqlQuery.Connection.ApiRoute
                 },
+                DBConnectionId = sqlQuery.ConnectionId,
                 OutputDescription = sqlQuery.OutputDescription
             };
         }

--- a/Querier.Api/Application/Interfaces/Services/ISqlQueryService.cs
+++ b/Querier.Api/Application/Interfaces/Services/ISqlQueryService.cs
@@ -13,6 +13,6 @@ namespace Querier.Api.Application.Interfaces.Services
         Task<SqlQueryDto> UpdateQueryAsync(SqlQueryDto query, Dictionary<string, object> sampleParameters = null);
         Task DeleteQueryAsync(int id);
 
-        Task<DataPagedResult<dynamic>> ExecuteQueryAsync(int queryId, DataRequestParametersWtihSQLParametersDto dataRequestParameters);
+        Task<DataPagedResult<dynamic>> ExecuteQueryAsync(int queryId, DataRequestParametersWithSQLParametersDto dataRequestParameters);
     }
 }

--- a/Querier.Api/Controllers/SQLQueryController.cs
+++ b/Querier.Api/Controllers/SQLQueryController.cs
@@ -281,7 +281,7 @@ namespace Querier.Api.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<ActionResult<DataPagedResult<dynamic>>> ExecuteAsync(
             int id,
-            [FromBody] DataRequestParametersWtihSQLParametersDto parameters)
+            [FromBody] DataRequestParametersWithSQLParametersDto parameters)
         {
             try
             {

--- a/Querier.Api/Domain/Common/Models/DataRequestParametersWtihSQLParametersDto.cs
+++ b/Querier.Api/Domain/Common/Models/DataRequestParametersWtihSQLParametersDto.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Querier.Api.Domain.Common.Models;
 
-public class DataRequestParametersWtihSQLParametersDto : DataRequestParametersDto
+public class DataRequestParametersWithSQLParametersDto : DataRequestParametersDto
 {
-    public Dictionary<string, object> Parameters { get; set; }
+    public Dictionary<string, object> Parameters { get; set; } = new Dictionary<string, object>();
 }

--- a/Querier.Api/Infrastructure/Services/SQLQueryService.cs
+++ b/Querier.Api/Infrastructure/Services/SQLQueryService.cs
@@ -290,7 +290,7 @@ namespace Querier.Api.Infrastructure.Services
             }
         }
 
-        public async Task<DataPagedResult<dynamic>> ExecuteQueryAsync(int id, DataRequestParametersWtihSQLParametersDto dataRequestParameters)
+        public async Task<DataPagedResult<dynamic>> ExecuteQueryAsync(int id, DataRequestParametersWithSQLParametersDto dataRequestParameters)
         {
             try
             {


### PR DESCRIPTION
…rs dictionary

- Renamed DataRequestParametersWtihSQLParametersDto to DataRequestParametersWithSQLParametersDto
- Updated related interfaces, services, and controllers to use the corrected class name
- Added default empty dictionary initialization for Parameters property
- Added DBConnectionId to SQLQueryDTO mapping